### PR TITLE
feat: add counterpart for dr bid result

### DIFF
--- a/pt/endpoints/dr/model.py
+++ b/pt/endpoints/dr/model.py
@@ -93,5 +93,5 @@ def get_start_of_day(day: datetime):
     return datetime.combine(day.date(), datetime.min.time())
 
 
-def get_counterpart(account: str):
+def get_user_by_account(account: str):
     return User.query.filter_by(account=account).first()

--- a/pt/endpoints/dr/model.py
+++ b/pt/endpoints/dr/model.py
@@ -91,3 +91,7 @@ def get_tomorrow(today: datetime):
 
 def get_start_of_day(day: datetime):
     return datetime.combine(day.date(), datetime.min.time())
+
+
+def get_counterpart(account: str):
+    return User.query.filter_by(account=account).first()

--- a/pt/endpoints/dr/resource.py
+++ b/pt/endpoints/dr/resource.py
@@ -6,7 +6,7 @@ from loguru import logger
 
 from utils.oauth import auth, g
 
-from .model import DRBidModel, aggregator_accept, user_add_bid, get_counterpart
+from .model import DRBidModel, aggregator_accept, user_add_bid, get_user_by_account
 
 
 class DRBid(Resource):
@@ -154,14 +154,14 @@ class DRBidResult(Resource):
                 "executor": bid.executor,
                 "acceptor": bid.acceptor,
                 "counterpart_name": (
-                    get_counterpart(bid.executor).username
+                    get_user_by_account(bid.executor).username
                     if g.is_aggregator
-                    else get_counterpart(bid.acceptor).username
+                    else get_user_by_account(bid.acceptor).username
                 ),
                 "counterpart_address": (
-                    get_counterpart(bid.executor).address
+                    get_user_by_account(bid.executor).address
                     if g.is_aggregator
-                    else get_counterpart(bid.acceptor).address
+                    else get_user_by_account(bid.acceptor).address
                 ),
                 "start_time": bid.start_time.strftime("%Y-%m-%d %H:%M:%S"),
                 "end_time": bid.end_time.strftime("%Y-%m-%d %H:%M:%S") if bid.end_time else None,


### PR DESCRIPTION
修改 dr_result api, 回傳 counterpart

對象: 如果登入的人是 aggregator，對象顯示 executor; 如果登入的人是 bems， 對象顯示 acceptor
地址: 如果登入的人是 aggregator，地址顯示 executor 的地址; 如果登入的人是 bems， 地址顯示 acceptor 的地址


---
UPDATE:
- rebase to develop
- base branch 指向 develop
- 原本對 new-eth-match 的 PR 因爲這個 changes 比較少所以使用把 base 改回 develop
